### PR TITLE
Remove windowVue, icons and app JS imports

### DIFF
--- a/rocket/elements/head.twig
+++ b/rocket/elements/head.twig
@@ -22,10 +22,4 @@
 
 {% include 'elements/scripts/head.twig' %}
 {% include 'elements/variables.twig' %}
-
-<script type="module" src="{{ '/dist/vendor/windowVue.js' | vendor_url }}"></script>
-<script type="module" src="{{ '/dist/vendor/icons.js' | vendor_url }}"></script>
-
 {% include 'elements/scripts/components.twig' ignore missing %}
-
-<script type="module" src="{{ '/dist/vendor/app.js' | vendor_url }}"></script>


### PR DESCRIPTION
## Descrição

Com a atualização de build único do Bart, o arquivo `windowVue.js`, os componentes .Vue e o `app.js` é adicionado no arquivo `components.twig` de forma automática.

Precisamos remover do arquivo de templates, pois ao restaurar os arquivos esse imports não podem existir no arquivo `head` senão causa conflito.

## Contexto e motivação

https://github.com/somosyampi/open-code-editor-api/pull/81


