### PR TITLE
Adicionando imports no `components.twig` padrão

### DIFF
--- a/rocket/elements/scripts/components.twig
+++ b/rocket/elements/scripts/components.twig
@@ -1,3 +1,5 @@
+<script type="module" src="{{ '/dist/vendor/windowVue.js' | components_url }}"></script>
+<script type="module" src="{{ '/dist/vendor/icons.js' | components_url }}"></script>
 <script type='module' src='{{ '/components/CookiesWarning.js' | components_url }}'></script>
 <script type='module' src='{{ '/components/GridCollectionBoxProduct.js' | components_url }}'></script>
 <script type='module' src='{{ '/components/banners/BannerStopwatch.js' | components_url }}'></script>
@@ -122,3 +124,4 @@
 <script type='module' src='{{ '/components/text-button-2-banners/SectionGridCollection.js' | components_url }}'></script>
 <script type='module' src='{{ '/components/text-button-2-banners/SectionTextButton2Banners.js' | components_url }}'></script>
 <script type='module' src='{{ '/components/top-ratings/TopRatings.js' | components_url }}'></script>
+<script type="module" src="{{ '/dist/vendor/app.js' | components_url }}"></script>


### PR DESCRIPTION
Ao restaurar a loja, o sistema não publica ela novamente, então o Bart não regera o `components.twig`. Por isso, estamos adicionando esses _imports_ diretamente aqui nos templates.