### PR TITLE
Corrige altura dos banners no componente Text Button 2 Banners

### DIFF
--- a/rocket/components/text-button-2-banners/SectionTextButton2Banners.vue
+++ b/rocket/components/text-button-2-banners/SectionTextButton2Banners.vue
@@ -40,7 +40,7 @@
                     '--has-link': !!banner.link,
                 }"
                 width="158"
-                height="237"
+                height="auto"
                 @click="handleClick(banner)"
             />
         </div>


### PR DESCRIPTION
## O que foi alterado

No componente `SectionTextButton2Banners.vue`, o atributo `height` da imagem do banner foi alterado de um valor fixo (`237`) para `auto`.

## Por quê

O valor fixo de altura (`237`) forçava a imagem do banner a uma altura arbitrária, distorcendo a proporçãodas imagens enviadas. Usando `height="auto"`, a altura passa a acompanhar a largura de forma proporcional, preservando o aspect ratio original de cada banner.