### PR TITLE
Corrige o caminho do vendor no deploy dos assets do Rocket

### DIFF
--- a/.github/workflows/deploy_rocket_assets.yml
+++ b/.github/workflows/deploy_rocket_assets.yml
@@ -81,7 +81,7 @@ jobs:
           mkdir -p rocket-assets/components rocket-assets/css rocket-assets/dist/vendor
           cp -R .rocket-src/.open-store/dist/components/. rocket-assets/components/
           cp -R .rocket-src/public/css/. rocket-assets/css/
-          cp -R .rocket-src/.open-store/dist/vendor/. rocket-assets/dist/vendor/
+          cp -R .rocket-src/public/dist/vendor/. rocket-assets/dist/vendor/
 
       - name: Converter URLs sandbox -> producao (em memoria, sem commit)
         if: ${{ inputs.environment == 'production' }}


### PR DESCRIPTION
## Contexto

O workflow **Build & Deploy Rocket Assets** está falhando.

O build passa normalmente; a quebra acontece no step `Sincronizar saida em rocket-assets`:

```
cp: cannot stat '.rocket-src/.open-store/dist/vendor/.': No such file or directory
##[error]Process completed with exit code 1
```

## Causa

O diretório de saída do vendor mudou no `somosyampi/rocket`. O commit [`92005bea`](https://github.com/somosyampi/rocket/commit/92005bea) — *build(vite): change open store vendor output to public directory* (15/07) — alterou o `vite.config.build-js.js`:

```diff
     build: {
-        outDir: '.open-store/dist/vendor',
+        outDir: 'public/dist/vendor',
```

Como o workflow usa `rocket_ref: master`, ele passou a pegar esse commit e o `cp` ficou apontando para um caminho que não existe mais.

Comparando os logs:

| Run | Saída do `yarn build:ci` |
| --- | --- |
| 29360160248 (verde) | `.open-store/dist/vendor/axios.js` |
| 33101259244 (falha) | `public/dist/vendor/axios.js` |

Os dois `cp` anteriores do mesmo step continuam válidos: o `build-vue-files.mjs` ainda escreve os componentes em `.open-store/dist/components`, e o CSS continua vindo do `mix` em `public/css`. Só o vendor mudou de lugar.

## O que foi alterado

Uma linha em `.github/workflows/deploy_rocket_assets.yml`, apontando o `cp` do vendor para o novo caminho.

## Como testar

Rodar o workflow **Build & Deploy Rocket Assets** manualmente com `environment: sandbox` e `rocket_ref: master` e confirmar que:

1. O step `Sincronizar saida em rocket-assets` conclui sem erro.
2. O step `Deploy para o S3` sobe os arquivos de `rocket-assets/dist/vendor/` (`axios.js`, `vuex.js`, `splidejs.js`, etc.).
